### PR TITLE
VE-4264: VE-4263: add new TIN parser

### DIFF
--- a/ironhide/lambdas/tin_parser/function.cdk.ts
+++ b/ironhide/lambdas/tin_parser/function.cdk.ts
@@ -1,0 +1,61 @@
+import * as path from 'path'
+import * as lambda from '@aws-cdk/aws-lambda'
+import * as iam from '@aws-cdk/aws-iam'
+import * as ssm from '@aws-cdk/aws-ssm'
+import * as events from '@aws-cdk/aws-events'
+import * as cdk from '@aws-cdk/core'
+import { LambdaWithPermissions, LambdaWithPermissionsProps } from '@constructs/basic'
+import { iam_perms, EnvironmentTypes } from '@constructs/utils'
+
+const functionName = 'TINParser'
+
+export interface LambdaFunctionProps {
+  eventBus: events.EventBus,
+  environment: EnvironmentTypes,
+}
+
+export const lambdaFunction = (
+  scope: cdk.Stack,
+  props: LambdaFunctionProps
+): void => {
+  // Standard params
+  const serviceApiUrl = ssm.StringParameter.valueForStringParameter(
+    scope, '/veda/SERVICE_API_URL'
+  )
+  const serviceApiId = ssm.StringParameter.valueForStringParameter(
+    scope, '/veda/SERVICE_API_ID'
+  )
+  const artifactBucket = ssm.StringParameter.valueForStringParameter(
+    scope, '/veda/ARTIFACT_BUCKET'
+  )
+
+  const funcProps: LambdaWithPermissionsProps = {
+    eventBus: props.eventBus,
+    functionProps: {
+      functionName: functionName,
+      code: lambda.Code.fromAsset(path.join(__dirname)),
+      handler: 'index.handler',
+      runtime: lambda.Runtime.PYTHON_3_7,
+      timeout: cdk.Duration.minutes(5),
+      memorySize: 2048,
+      reservedConcurrentExecutions: 20,
+      environment: {
+        ENVIRONMENT: 'production',
+        SERVICE_API_URL: serviceApiUrl,
+        SERVICE_API_ID: serviceApiId
+      },
+    } as lambda.FunctionProps,
+    functionPolicies: [
+      new iam.PolicyStatement({
+        actions: [...iam_perms.S3_GET, ...iam_perms.S3_PUT],
+        resources: [
+          `arn:aws:s3:::${artifactBucket}`,
+          `arn:aws:s3:::${artifactBucket}/*`
+        ]
+      }),
+    ],
+    environment: props.environment
+  }
+
+  new LambdaWithPermissions(scope, functionName, funcProps)
+}

--- a/ironhide/lambdas/tin_parser/index.py
+++ b/ironhide/lambdas/tin_parser/index.py
@@ -1,0 +1,30 @@
+"""
+TIN parser lambda
+"""
+
+import logging
+import traceback
+import json
+from typing import Dict, Any
+
+from ironhide.parsers.tin import TINParser
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def handler(event: Dict[str, Any], lambda_context: Dict[str, Any]):
+    """
+    Handle events for TIN parsing.
+    """
+
+    message = json.loads(event["Records"][0]["body"])
+
+    try:
+        tins = TINParser.parse(message)
+        return tins
+    except Exception:  # pylint: disable=broad-except
+        logger.error("Lambda Error")
+        logger.error(traceback.format_exc())
+        return False

--- a/ironhide/models/tin.py
+++ b/ironhide/models/tin.py
@@ -6,8 +6,7 @@ from ironhide.models.model import Model
 
 @dataclass
 class TINModel(Model):
-    """taxpayer id data model"""
+    """taxpayer id data model, holds TIN and a count of that TIN in each roster."""
 
-    area_number: str
-    group_number: str
-    serial_number: str
+    tin: str
+    count: int

--- a/ironhide/parsers/tin.py
+++ b/ironhide/parsers/tin.py
@@ -1,0 +1,36 @@
+"""Parse TIN Number"""
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import Dict, List, Union, Optional, Any
+
+from optimus.models.tin import TINModel
+from optimus.parsers.parser import Parser
+from optimus.models.model import Model
+
+
+class TINParser(Parser):
+    """TIN Parser."""
+
+    @classmethod
+    def parse(cls, raw: Union[str, Dict[str, str]]) -> Model:
+        """
+        Parse input.
+
+        Atributes
+        ---------
+        raw
+        """
+
+        try:
+            for k, v in raw.items():
+                for i in ("111111111", "333333333", "666666666", "123456789"):
+                    if i == v:
+                        raise Exception
+                elif not k:
+                    raise Exception
+                else:
+                    return TINModel(**v)
+
+        except Exception as e:
+            raise e

--- a/ironhide/parsers/tin.py
+++ b/ironhide/parsers/tin.py
@@ -1,7 +1,6 @@
 """Parse TIN Number"""
 from __future__ import annotations
 
-from contextlib import suppress
 from typing import Dict, List, Union, Optional, Any
 
 from optimus.models.tin import TINModel
@@ -9,28 +8,57 @@ from optimus.parsers.parser import Parser
 from optimus.models.model import Model
 
 
+class Counter:
+    """Count numbers of things"""
+
+    def __init__():
+        """init"""
+        self.counts = {}
+
+    def add_item(self, item):
+        """add an item to the counter"""
+        if item not in self.counts:
+            self.counts[item] = 1
+        else:
+            self.counts[item] = self.counts[item] + 1
+
+    def get_counts(self):
+        """
+        get all counts
+        """
+        return self.counts
+
+
 class TINParser(Parser):
     """TIN Parser."""
 
     @classmethod
-    def parse(cls, raw: Union[str, Dict[str, str]]) -> Model:
+    def parse(cls, raw: Union[str, List[str]]) -> Model:
         """
         Parse input.
 
-        Atributes
-        ---------
+        Attributes
+        ----------
         raw
         """
 
         try:
-            for k, v in raw.items():
+            for item in raw:
+                # Bad TINs:
                 for i in ("111111111", "333333333", "666666666", "123456789"):
-                    if i == v:
+                    if i == item:
                         raise Exception
-                elif not k:
-                    raise Exception
-                else:
-                    return TINModel(**v)
+                counter = Counter()
+                counter.add_item(item)
+
+            all_counts = counter.get_counts()
+
+            models = []
+            for k, v in all_counts:
+                models.append(TINModel(tin=k, count=v))
+
+            return models
 
         except Exception as e:
-            raise e
+            print("An error occurred")
+            return

--- a/ironhide/parsers/tin.py
+++ b/ironhide/parsers/tin.py
@@ -43,13 +43,13 @@ class TINParser(Parser):
         """
 
         try:
-            for item in raw:
+            for i in raw:
                 # Bad TINs:
-                for i in ("111111111", "333333333", "666666666", "123456789"):
-                    if i == item:
+                for j in ("111111111", "333333333", "666666666", "123456789"):
+                    if j == i:
                         raise Exception
                 counter = Counter()
-                counter.add_item(item)
+                counter.add_item(i)
 
             all_counts = counter.get_counts()
 

--- a/ironhide/parsers/tin.py
+++ b/ironhide/parsers/tin.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 from typing import Dict, List, Union, Optional, Any
 
-from optimus.models.tin import TINModel
-from optimus.parsers.parser import Parser
-from optimus.models.model import Model
+from ironhide.models.tin import TINModel
+from ironhide.parsers.parser import Parser
+from ironhide.models.model import Model
 
 
 class Counter:

--- a/tests/unit/parsers/tin/test_tin.py
+++ b/tests/unit/parsers/tin/test_tin.py
@@ -6,6 +6,7 @@ import pytest
 from faker import Faker
 
 from optimus.parsers.tin import TINParser
+from optimus.models.tin import TINModel
 
 
 Faker.seed(randint(0, 1000000))

--- a/tests/unit/parsers/tin/test_tin.py
+++ b/tests/unit/parsers/tin/test_tin.py
@@ -1,0 +1,23 @@
+"""Testing module for social security models."""
+
+from random import randint
+
+import pytest
+from faker import Faker
+
+from optimus.parsers.tin import TINParser
+
+
+Faker.seed(randint(0, 1000000))
+fake = Faker(["en-US"])
+
+SSNS = [[fake.ssn("SSN"), "SSN"] for _ in range(50)]
+INVALID_NUMS = [[f"{_}{_+3}", "INVALID"] for _ in range(50)]
+ITINS = [[fake.ssn("ITIN"), "ITIN"] for _ in range(50)]
+EINS = [[fake.ssn("EIN"), "EIN"] for _ in range(50)]
+
+
+@pytest.mark.parametrize("tin, tin_type", ITINS)
+def test_tin(tin, tin_type):
+    # TODO: add tests
+    pass

--- a/tests/unit/parsers/tin/test_tin.py
+++ b/tests/unit/parsers/tin/test_tin.py
@@ -20,4 +20,4 @@ INVALID_NUMS = [[f"{_}{_+3}", "INVALID"] for _ in range(50)]
 @pytest.mark.parametrize("tin, tin_type", SSNS)
 def test_tin(tin, tin_type):
     # TODO: add tests
-    pass
+    assert False

--- a/tests/unit/parsers/tin/test_tin.py
+++ b/tests/unit/parsers/tin/test_tin.py
@@ -1,4 +1,4 @@
-"""Testing module for social security models."""
+"""Testing module for TIN models."""
 
 from random import randint
 
@@ -11,13 +11,12 @@ from optimus.parsers.tin import TINParser
 Faker.seed(randint(0, 1000000))
 fake = Faker(["en-US"])
 
+# SSNs can be used as a TINs
 SSNS = [[fake.ssn("SSN"), "SSN"] for _ in range(50)]
 INVALID_NUMS = [[f"{_}{_+3}", "INVALID"] for _ in range(50)]
-ITINS = [[fake.ssn("ITIN"), "ITIN"] for _ in range(50)]
-EINS = [[fake.ssn("EIN"), "EIN"] for _ in range(50)]
 
 
-@pytest.mark.parametrize("tin, tin_type", ITINS)
+@pytest.mark.parametrize("tin, tin_type", SSNS)
 def test_tin(tin, tin_type):
     # TODO: add tests
     pass

--- a/tests/unit/parsers/tin/test_tin.py
+++ b/tests/unit/parsers/tin/test_tin.py
@@ -5,8 +5,8 @@ from random import randint
 import pytest
 from faker import Faker
 
-from optimus.parsers.tin import TINParser
-from optimus.models.tin import TINModel
+from ironhide.parsers.tin import TINParser
+from ironhide.models.tin import TINModel
 
 
 Faker.seed(randint(0, 1000000))


### PR DESCRIPTION
`User Story -- VE-4264`
```
*Description*
As a roster specialist, I need summary information about the number of unique TINs that appear on a roster, so that I can feed this information into the NBAX system.

*Definition of Done*
Unique TINs are parsed and counted. TIN parser is deployable to the cloud.
```

This PR:
 * Add a new TIN parser. This TIN parser counts up unique TINs and produces a model of unique TIN counts for use downstream
 * Adds CDK configuration

Questions:
 * Not sure how best to test this parser. Any ideas?